### PR TITLE
Replace instances of "it is" (it's) with proper form of its.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # DespawningSpawners
-Limiting the amount of spawns a spawner can do in it's lifetime
+Limiting the amount of spawns a spawner can do in its lifetime.

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -2,7 +2,7 @@
 {
   "modid": "despawningspawners",
   "name": "Despawning Spawners",
-  "description": "Limiting the amount of spawns a spawner can do in it's lifetime.",
+  "description": "Limiting the amount of spawns a spawner can do in its lifetime.",
   "version": "${version}",
   "mcversion": "${mcversion}",
   "url": "",


### PR DESCRIPTION
You won't believe it but "it's" is actually it is!
I was browsing through some mods in a modpack and wouldn't you know it this mod is in the pack! Nice.
Unfortunately, I came across this wildly unprofessional grammatical error!
I've went ahead and patched that up for ya. Take it, it's a gift from me.